### PR TITLE
[✨Feat] 지원서 페이지 API 연동

### DIFF
--- a/src/routes/Applicants.jsx
+++ b/src/routes/Applicants.jsx
@@ -70,9 +70,14 @@ function Applicants() {
     }
 
     try {
-      const API_URL = import.meta.env.VITE_API_URL;
+      const API_URL = import.meta.env.VITE_API_BASE_URL;
 
-      const response = await axios.post(`${API_URL}/check/babylions/`, {
+      const url =
+        pageMode === "FORM_CHECK"
+          ? `${API_URL}/application/check-submission/` // 제출 여부 조회 API
+          : `${API_URL}/check/babylions/`; // 합격자 조회 API
+
+      const response = await axios.post(url, {
         name,
         phone_number: tel,
         email,
@@ -86,11 +91,27 @@ function Applicants() {
       }
 
       if (pageMode === "FORM_CHECK") {
-        navigate("/checksubmit", {
-          // 연동시 지원자의 지원서 제출 여부에 따라 연결되는 페이지를 분기처리하는 코드를 추가하셔야 할 것 같아요!!
-          // 일단 제출 완료 페이지로 연결해두었습니당
-          state: { name, email },
-        });
+        const submitted = data?.data?.submitted;
+
+        if (submitted === true) {
+          // 성공 - 제출 시
+          navigate("/checksubmit", {
+            state: {
+              name,
+              email,
+              submittedAt: data.data.submitted_at,
+            },
+          });
+        } else {
+          // 성공 - 미제출 시
+          navigate("/noexist", {
+            state: {
+              name,
+              email,
+            },
+          });
+        }
+        return;
       }
 
       if (pageMode === "RESULT") {

--- a/src/routes/WriteAnswer.jsx
+++ b/src/routes/WriteAnswer.jsx
@@ -33,8 +33,6 @@ function WriteAnswer() {
   const isEdit = location.state?.isEdit ?? false;
   const formData = location.state?.formData ?? null;
 
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
   useEffect(() => {
     if (!nextButtonRef.current) return;
 
@@ -49,7 +47,6 @@ function WriteAnswer() {
     );
 
     observer.observe(nextButtonRef.current);
-
     return () => observer.disconnect();
   }, []);
 
@@ -84,47 +81,37 @@ function WriteAnswer() {
     };
   }, []);
 
-  const submitApplication = async () => {
-    if (!isFormValid || isSubmitting) return;
+  const goConfirm = () => {
+    if (!isFormValid) return;
 
-    try {
-      setIsSubmitting(true);
+    const payload = {
+      name: formData?.name,
+      phone_number: formData?.phone_number,
+      email: formData?.email,
+      student_id: formData?.student_id,
+      department: formData?.department,
+      academic_status: formData?.academic_status,
+      part: formData?.part,
 
-      const payload = {
-        name: formData?.name,
-        phone_number: formData?.phone_number,
-        email: formData?.email,
-        student_id: formData?.student_id,
-        department: formData?.department,
-        academic_status: formData?.academic_status,
-        part: formData?.part,
+      common_answers: [
+        { question_number: 1, answer: common1 },
+        { question_number: 2, answer: common2 },
+      ],
+      part_answers: [
+        { question_number: 1, answer: part1 },
+        { question_number: 2, answer: part2 },
+      ],
+    };
 
-        common_answers: [
-          { question_number: 1, answer: common1 },
-          { question_number: 2, answer: common2 },
-        ],
-        part_answers: [
-          { question_number: 1, answer: part1 },
-          { question_number: 2, answer: part2 },
-        ],
-      };
-
-      const res = await axios.post(`${API_URL}/application/`, payload);
-
-      navigate("/WriteConfirm", {
-        state: {
-          isEdit: location.state?.isEdit ?? false,
-          fromResult,
-          formData,
-          answerData: { common1, common2, part1, part2, TryJava },
-          applicationData: res.data,
-        },
-      });
-    } catch (err) {
-      console.error("POST /application/ error:", err);
-    } finally {
-      setIsSubmitting(false);
-    }
+    navigate("/WriteConfirm", {
+      state: {
+        isEdit,
+        fromResult,
+        formData,
+        answerData: { common1, common2, part1, part2, TryJava },
+        payload,
+      },
+    });
   };
 
   return (
@@ -267,7 +254,7 @@ function WriteAnswer() {
               //     answerData: { common1, common2, part1, part2, TryJava },
               //   },
               // });
-              submitApplication();
+              goConfirm();
             }}>
             {isEdit ? "수정 완료" : "다음으로"}
           </N.NextButton>

--- a/src/routes/WriteConfirm.jsx
+++ b/src/routes/WriteConfirm.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
 import { useRef } from "react";
+import axios from "axios";
 import * as N from "@styles/WriteConfirmStyle";
 
 import Header from "@components/Header/HeaderSubExit";
@@ -8,6 +9,8 @@ import Footer from "@components/Footer";
 
 import Step4 from "@/assets/icons/Step4.svg";
 import Up from "@/assets/icons/Up.svg";
+
+const API_URL = import.meta.env.VITE_API_BASE_URL;
 
 function WriteConfirm() {
   const nextButtonRef = useRef(null);
@@ -20,6 +23,7 @@ function WriteConfirm() {
   const isEdit = location.state?.isEdit ?? false;
   const formData = location.state?.formData ?? {};
   const answerData = location.state?.answerData;
+  const payload = location.state?.payload ?? null;
 
   const [form, setForm] = useState(formData);
 
@@ -70,6 +74,16 @@ function WriteConfirm() {
     });
   };
 
+  const submitFinal = async () => {
+    if (!payload) {
+      console.error("payload is missing");
+      return;
+    }
+
+    await axios.post(`${API_URL}/application/`, payload);
+    navigate("/applicationformdone");
+  };
+
   return (
     <>
       <Header title="서류 지원서 작성"></Header>
@@ -83,17 +97,7 @@ function WriteConfirm() {
           <N.InformationFormGrid>
             <N.FormTitleBox>
               <N.InfoTitle>인적사항</N.InfoTitle>
-              <N.InfoEdit
-                onClick={() => {
-                  navigate("/writeinformation", {
-                    state: {
-                      isEdit: true,
-                      formData: form,
-                    },
-                  });
-                }}>
-                수정하기
-              </N.InfoEdit>
+              <N.InfoEdit onClick={handleEdit}>수정하기</N.InfoEdit>
             </N.FormTitleBox>
             <N.InfoBox>
               <N.InfoNameText>이름</N.InfoNameText>
@@ -159,12 +163,7 @@ function WriteConfirm() {
           <N.UpIcon src={Up} alt="위로"></N.UpIcon>
         </N.Fixed>
         <N.NextButtonGrid ref={nextButtonRef}>
-          <N.NextButton
-            onClick={() => {
-              navigate("/applicationformdone");
-            }}>
-            제출하기
-          </N.NextButton>
+          <N.NextButton onClick={submitFinal}>제출하기</N.NextButton>
         </N.NextButtonGrid>
       </N.Space>
       <Footer />

--- a/src/routes/WriteInformation.jsx
+++ b/src/routes/WriteInformation.jsx
@@ -37,7 +37,7 @@ function WriteInformation() {
       setPhone(data?.phone_number ?? "");
       setMail(data?.email ?? "");
       setLesson(data?.department ?? "");
-      setLesson(data?.academic_status ?? "");
+      setStudent(data?.academic_status ?? "");
       setNumber(data?.student_id ?? "");
 
       const partMapFromServer = {


### PR DESCRIPTION
### 📑 이슈 번호

- close #48 

### ✨️ 작업 내용

- 지원서 작성 페이지 연동
- 지원서 제출 여부 조회 연동

### 💭 코멘트

- 지원서 중복 여부 확인 연동 남았습니다.

### 📸 구현 결과
<img width="1823" height="1052" alt="image" src="https://github.com/user-attachments/assets/ccf5b037-3450-4a40-a273-c135618f3fff" />